### PR TITLE
Generative AI documentation section

### DIFF
--- a/content/docs/1-Introduction/1-Flama.mdx
+++ b/content/docs/1-Introduction/1-Flama.mdx
@@ -57,7 +57,7 @@ The same one-line experience extends to large language models. <FlamaName /> pro
 LLMs, with **HuggingFace**, **vLLM**, and **MLX** backends auto-detected at load time, as well as a compatibility layer
 that exposes them through OpenAI, Anthropic, and Ollama compatible endpoints. It also ships a built-in **chatbot**
 application and native support for the **Model Context Protocol (MCP)**, to expose tools, resources, and prompts to AI
-agents. See the [Generative AI](/docs/generative-ai/introduction/) section for the details.
+agents. See the [Generative AI](/docs/generative-ai/overview/) section for the details.
 
 ## Domain Driven Design
 

--- a/content/docs/2-Getting Started/2-Quickstart.mdx
+++ b/content/docs/2-Getting Started/2-Quickstart.mdx
@@ -178,7 +178,7 @@ To deep dive into the <FlamaName/> CLI, please go to the [Flama CLI section](/do
 interested in learning how to serve predictive ML models with <FlamaName />, head to the
 [Predictive AI](/docs/predictive-ai/packaging-models/) section. And if you want to serve large language models,
 build a chatbot, or expose tools through the Model Context Protocol, see the
-[Generative AI](/docs/generative-ai/introduction/) section.
+[Generative AI](/docs/generative-ai/overview/) section.
 
 If instead you are bringing an existing project to a newer version of <FlamaName />, the
 [Upgrading](/docs/getting-started/upgrading/) guide walks you through migrating your codebase step by step.

--- a/content/docs/6-Generative AI/1-Overview.mdx
+++ b/content/docs/6-Generative AI/1-Overview.mdx
@@ -1,0 +1,139 @@
+---
+title: Overview
+wip: true
+---
+
+<FlamaName /> began life as a framework for productionising machine-learning models with as little ceremony as
+possible. With the 2.0 release, that same one-line philosophy extends to generative AI: serving a large language model
+(LLM) behind a production-ready HTTP API is now a first-class citizen of the framework. This section introduces the
+concepts behind generative serving in <FlamaName />, explains why they matter, and walks you through serving your own
+models, building a chat interface, and exposing tools to AI clients through the Model Context Protocol (MCP).
+
+## What is generative AI serving?
+
+In <FlamaName />, **generative AI serving** is the process of exposing a packaged generative model, typically a large
+language model, behind a set of HTTP endpoints that speak the protocols your clients already understand. Where a
+*predictive* model answers "what is this?" by returning a label or a score, a *generative* model answers "create
+something that satisfies this description" by streaming back tokens that compose into text, code, or structured tool
+calls.
+
+The headline benefit is that you do not have to choose between writing your own serving stack and adopting a heavyweight
+inference server. <FlamaName /> packages a model into a single artifact and serves it through the same application that
+already hosts your REST endpoints, your predictive models, and your business logic.
+
+**Why does it matter?**
+
+- **Compatibility**: Existing clients written for OpenAI, Anthropic, or Ollama can talk to your model without code
+  changes, because <FlamaName /> speaks those dialects natively.
+- **Portability**: The same packaged model runs on whichever runtime your hardware offers, with the framework selecting
+  the backend at load time rather than baking it into the artifact.
+- **Streaming-first**: Responses stream over Server-Sent Events (SSE) by default, so first-token latency stays low and
+  long generations remain responsive.
+- **Uniformity**: Generative models are registered, injected, and inspected exactly like the predictive models covered
+  in the [Predictive AI](/docs/predictive-ai/packaging-models/) section, so everything you already know carries
+  across.
+- **Tooling**: A built-in chat interface and native MCP support turn a bare model into an interactive application and an
+  agent-ready tool provider.
+
+## Key concepts
+
+Before serving a model, let us establish four concepts that this section builds upon. Together they describe how a
+request travels from a client, through a *dialect*, into a *transport*, down to a *backend*, and back out through the
+*decoder*.
+
+### Dialects
+
+A **dialect** (also called a *serving layer*) is the wire protocol a client uses to talk to your model. <FlamaName />
+ships four dialects, each mounted under its own path prefix so a single resource can speak several at once:
+
+| Dialect | Prefix | Representative routes |
+|---|---|---|
+| **Native** | _(none)_ | `/query/`, `/stream/`, `/chat/` |
+| **OpenAI** | `/openai` | `/v1/chat/completions`, `/v1/completions`, `/v1/responses`, `/v1/models` |
+| **Anthropic** | `/anthropic` | `/v1/messages`, `/v1/models` |
+| **Ollama** | `/ollama` | `/api/chat`, `/api/generate`, `/api/tags` |
+
+The native dialect is the channel-aware <FlamaName /> protocol and powers the built-in chat interface; the others are
+drop-in compatible with the corresponding vendor clients.
+
+### Backends
+
+A **backend** is the runtime that actually executes the model. <FlamaName /> integrates with
+[HuggingFace](https://huggingface.co/) transformers, [vLLM](https://docs.vllm.ai/) on Linux with CUDA, and
+[MLX](https://ml-explore.github.io/mlx/) on Apple Silicon. The choice is *hardware-driven and not persisted* in the
+artifact: at load time the framework picks vLLM when its package is importable and MLX when `mlx.core` is importable, so
+the very same `.flm` file runs wherever you deploy it.
+
+### Transports
+
+A **transport** is the shape of the input you send to the model. There are three:
+
+- *raw*: the prompt is forwarded verbatim, without any chat template.
+- *chat*: a single-turn prompt is rendered through the model's chat template, with an optional system instruction.
+- *conversation*: a multi-turn list of messages is rendered through the chat template.
+
+When you do not specify a transport, the model uses its default: `chat` if the backend exposes a chat template, and
+`raw` otherwise.
+
+### Decoder and channels
+
+Modern models interleave several kinds of output in a single stream: user-visible text, hidden reasoning, and structured
+tool calls. The **decoder** splits that stream into typed events tagged by **channel**. The `output` channel carries the
+user-visible answer; other channels (such as `thought` or `analysis`) carry reasoning the model emits between markers
+like `<think>...</think>`; and `<tool_call>...</tool_call>` blocks are parsed into structured tool events. The decoder
+auto-detects the right strategy when the model starts, so most models work without any configuration.
+
+## Base application
+
+To ground the discussion, here is the minimal skeleton we will build upon throughout this section. It registers a single
+packaged LLM under `/llm/`, speaking both the native and OpenAI dialects:
+
+```python
+# examples/generative_ai.py
+import flama
+from flama import Flama
+
+app = Flama(
+    openapi={
+        "info": {
+            "title": "Generative AI API",
+            "version": "1.0.0",
+            "description": "Serving large language models with Flama 🔥",
+        },
+    },
+    docs="/docs/",
+)
+
+app.models.add_model(
+    path="/llm/",
+    model="google_gemma-4-E2B-it.flm",
+    name="assistant",
+    serving=("native", "openai"),
+)
+
+
+if __name__ == "__main__":
+    flama.run(flama_app=app, server_host="0.0.0.0", server_port=8000)
+```
+
+This is a complete, runnable generative API. Over the following pages we will see where the `.flm` file comes from, how
+the serving layers expose the model, how to turn it into an interactive chat application, and how to expose tools to AI
+agents through MCP.
+
+## What comes next
+
+This section is a progressive, hands-on guide. Each page introduces one building block and demonstrates it with working
+code:
+
+- **Overview** (this page): the concepts behind generative serving in <FlamaName />.
+- **[Getting models](/docs/generative-ai/getting-models/)**: fetching and packaging large language models as `.flm`
+  artifacts with the <FlamaName /> CLI.
+- **[Serving LLMs](/docs/generative-ai/serving-llms/)**: registering models programmatically, choosing serving
+  dialects, and interacting with them over HTTP.
+- **[Chatbot application](/docs/generative-ai/chatbot-application/)**: the built-in chat interface and the
+  standalone chatbot template.
+- **[Model Context Protocol](/docs/generative-ai/model-context-protocol/)**: exposing tools, resources, and prompts
+  to AI clients with native MCP support.
+
+By the end, you will be able to serve any generative model behind the protocols your clients already speak, give it a
+chat interface, and make it an agent-ready tool provider.

--- a/content/docs/6-Generative AI/2-Getting models.mdx
+++ b/content/docs/6-Generative AI/2-Getting models.mdx
@@ -1,0 +1,124 @@
+---
+title: Getting models
+wip: true
+---
+
+Before serving a large language model (LLM) with <FlamaName />, you need it packaged as a self-contained artifact. In
+the [Predictive AI](/docs/predictive-ai/packaging-models/) section we saw how traditional models are serialised
+into **.flm** files; generative models use the very same format, but rather than serialising a model you have trained
+yourself, you typically *fetch* a pre-trained model from a hub and let <FlamaName /> package it for you. This page covers
+the `flama get` command, the one-step way to download and package a model ready for serving.
+
+## What is an LLM artifact?
+
+In <FlamaName />, an **LLM artifact** is a **.flm** file (a *Flama Lightweight Model*) whose manifest records the model
+**family** as `llm`. As we saw with predictive models, a `.flm` file bundles the model weights, its configuration, and
+the metadata <FlamaName /> needs to build a serving application around it. The family is the crucial difference: it is
+persisted in the manifest at download time and drives runtime dispatch, so an `llm` artifact is routed through the LLM
+machinery (vLLM or MLX) while an `ml` artifact runs through its predictive framework.
+
+**Why does the family matter?**
+
+- **Dispatch**: The family tells <FlamaName /> whether to wrap the artifact in an `LLMResource` or a predictive
+  `ModelResource`, and which backend to load.
+- **Portability**: The on-disk weights are framework-agnostic; the family, not the original library, decides how they
+  are run, so the same artifact serves on vLLM (Linux/CUDA) or MLX (Apple Silicon).
+- **Immutability**: The family is fixed at packaging time and cannot be changed without repacking, which keeps the
+  serving behaviour reproducible across environments.
+
+## Fetching a model with `flama get`
+
+The `flama get` command downloads a model from a supported source and serialises it into a `.flm` artifact in a single
+step. Its inspection output describes the required options:
+
+```console
+flama get --help
+
+Usage: flama get [OPTIONS] MODEL_NAME
+
+  Download and package a model as .flm.
+
+  Download a model from a supported source and serialize it into Flama's .flm
+  format, ready for serving with 'flama serve' or interaction with 'flama
+  model'.
+
+Options:
+  --source [huggingface]          Model source provider.  [required]
+  --family [ml|llm]               Artifact family recorded in the manifest.
+                                  [required]
+  -o, --output TEXT               Output .flm path (default: <model-name>.flm).
+  --max-concurrent INTEGER RANGE  Maximum number of files to download
+                                  concurrently.  [default: 8; x>=1]
+  --help                          Show this message and exit.
+```
+
+Two options are required: `--source` selects the provider (currently [HuggingFace](https://huggingface.co/)), and
+`--family` declares whether the artifact is a traditional `ml` model or an `llm`. For generative models you always pass
+`--family llm`.
+
+## Examples
+
+Let us fetch a small instruction-tuned model so the examples in the rest of this section have something concrete to
+serve. We will use [Gemma 4 E2B](https://huggingface.co/google/gemma-4-E2B-it), the smallest model in the Gemma 4 family:
+
+```console
+flama get --source huggingface --family llm google/gemma-4-E2B-it
+
+Downloading ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 5.1 GB 24.3 MB/s 0:00:00
+Packaging...
+Model saved to google_gemma-4-E2B-it.flm
+```
+
+By default the artifact is written to `<model-name>.flm` with slashes replaced by underscores, hence
+`google_gemma-4-E2B-it.flm`. To choose a different path, pass `--output`:
+
+```console
+flama get --source huggingface --family llm google/gemma-4-E2B-it --output models/assistant.flm
+
+Downloading ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 5.1 GB 31.0 MB/s 0:00:00
+Packaging...
+Model saved to models/assistant.flm
+```
+
+### Inspecting the artifact
+
+Once the model is packaged, you can verify its metadata without loading the weights using the `flama model` command
+introduced in the [CLI section](/docs/flama-cli/model/). The `inspect` sub-command reads only the cheap metadata header:
+
+```console
+flama model google_gemma-4-E2B-it.flm inspect --pretty
+
+{
+    "manifest": [
+        "config.json",
+        "model.safetensors",
+        "tokenizer.json",
+        "tokenizer_config.json"
+    ],
+    "meta": {
+        "id": "0d7c3a4e-1f2b-4c8a-9e6d-5b4a3c2d1e0f",
+        "timestamp": "2026-06-13T09:12:44.512030",
+        "framework": {
+            "family": "llm",
+            "lib": "transformers",
+            "version": "4.57.0",
+            "config": null
+        },
+        "model": {
+            "obj": null,
+            "info": null,
+            "params": {},
+            "metrics": {}
+        },
+        "extra": {
+            "model_name": "google/gemma-4-E2B-it"
+        }
+    }
+}
+```
+
+Note the `framework.family` field set to `llm`: this is what tells <FlamaName /> to treat the artifact as a generative
+model when it is served. With a packaged model in hand, we are ready to serve it.
+
+In the [next page](/docs/generative-ai/serving-llms/) we will register this artifact in a <FlamaName /> application
+and interact with it over the native and vendor-compatible dialects.

--- a/content/docs/6-Generative AI/3-Serving LLMs.mdx
+++ b/content/docs/6-Generative AI/3-Serving LLMs.mdx
@@ -1,0 +1,248 @@
+---
+title: Serving LLMs
+wip: true
+---
+
+With a packaged model in hand, serving it is the same exercise as serving a predictive model: you register the artifact
+on a <FlamaName /> application under a URL path, and the framework wires up the endpoints. The difference is *which*
+endpoints, and which protocols they speak. In this page we register a large language model (LLM) programmatically, choose
+the serving dialects it should expose, and interact with it over HTTP, both buffered and streamed.
+
+This page mirrors the [Add models](/docs/predictive-ai/add-models/) page from the Predictive AI section; if you
+have served a predictive model before, the registration API will feel immediately familiar.
+
+## Registering a model
+
+Every <FlamaName /> application exposes a `models` module with an `add_model` method. For an LLM artifact,
+<FlamaName /> auto-detects the `llm` family from the manifest and wraps it in an `LLMResource`:
+
+```python
+app.models.add_model(
+    path="/llm/",
+    model="google_gemma-4-E2B-it.flm",
+    name="assistant",
+    serving=("native", "openai"),
+)
+```
+
+The arguments are:
+
+- **path**: the URL prefix under which the model's endpoints are mounted.
+- **model**: the local file path to the `.flm` artifact.
+- **name**: the resource name, used for dependency injection and OpenAPI tags.
+- **serving**: a tuple of dialect names to enable. When omitted, every available dialect is mounted.
+
+Registration is deliberately cheap: only the artifact's metadata header is read so the right resource class can be
+selected. The heavy deserialisation happens during application startup, after the server has bound its port, so models
+that weigh several gigabytes do not delay the boot.
+
+### Tuning generation defaults
+
+Default generation parameters are passed through `params`, and the special `reasoning` flag controls whether the model is
+asked to produce reasoning content:
+
+```python
+app.models.add_model(
+    path="/llm/",
+    model="google_gemma-4-E2B-it.flm",
+    name="assistant",
+    serving=("native", "openai"),
+    params={"temperature": 0.7, "max_tokens": 512, "reasoning": True},
+)
+```
+
+Reserved keys such as `reasoning` are lifted onto the resource; the remaining parameters (`temperature`, `max_tokens`,
+and any other generation hints) are forwarded to the backend on every request, and can be overridden per call.
+
+### Using a resource class
+
+For finer control, define an `LLMResource` subclass and register it with the `model_resource` decorator. This is the
+generative counterpart to a custom [model resource](/docs/predictive-ai/model-resource/):
+
+```python
+from flama.models import LLMResource
+
+
+@app.models.model_resource("/llm/")
+class Assistant(LLMResource):
+    name = "assistant"
+    verbose_name = "Assistant"
+    model_path = "google_gemma-4-E2B-it.flm"
+    serving = ("native", "openai")
+    reasoning = True
+    heartbeat_interval = 15.0
+```
+
+The `reasoning` attribute sets the resource default, and `heartbeat_interval` controls how often a comment-only
+heartbeat is emitted on idle streams to keep connections alive.
+
+## Serving dialects
+
+A **dialect** is the wire protocol a client uses to talk to the model. Each enabled dialect mounts its routes under a
+fixed prefix relative to the resource path, so one resource can serve several clients simultaneously.
+
+### Native
+
+The native dialect is the channel-aware <FlamaName /> protocol. Mounted directly under the resource path (no prefix), it
+exposes:
+
+- <Label color="green">GET</Label> **/llm/** Retrieve the model's introspection payload (metadata and bundled
+  artifacts).
+- <Label color="orange">PUT</Label> **/llm/** Configure the default generation parameters for the resource.
+- <Label color="blue">POST</Label> **/llm/query/** Send a prompt and receive a buffered response.
+- <Label color="blue">POST</Label> **/llm/stream/** Create a generation and receive a stream identifier.
+- <Label color="green">GET</Label> `/llm/stream/{stream_id}/` Consume the generation as Server-Sent Events (SSE).
+- <Label color="green">GET</Label> **/llm/chat/** The built-in HTML chat interface (covered in the
+  [next page](/docs/generative-ai/chatbot-application/)).
+
+### Vendor-compatible dialects
+
+The remaining dialects are drop-in compatible with the corresponding vendor clients, so you can point an existing SDK at
+your <FlamaName /> deployment by changing only its base URL:
+
+- **OpenAI** (prefix `/openai`): <Label color="blue">POST</Label> **/llm/openai/v1/chat/completions**,
+  <Label color="blue">POST</Label> **/llm/openai/v1/completions**, <Label color="blue">POST</Label>
+  **/llm/openai/v1/responses**, and <Label color="green">GET</Label> **/llm/openai/v1/models**.
+- **Anthropic** (prefix `/anthropic`): <Label color="blue">POST</Label> **/llm/anthropic/v1/messages** and
+  <Label color="green">GET</Label> **/llm/anthropic/v1/models**.
+- **Ollama** (prefix `/ollama`): <Label color="blue">POST</Label> **/llm/ollama/api/chat**,
+  <Label color="blue">POST</Label> **/llm/ollama/api/generate**, and <Label color="green">GET</Label>
+  **/llm/ollama/api/tags**, among others.
+
+## Transports
+
+A **transport** is the shape of the input you send. The native `query` and `stream` endpoints accept a `transport` field
+with three values:
+
+- **raw**: the `prompt` is forwarded verbatim, without a chat template.
+- **chat**: the `prompt` is rendered through the model's chat template, with an optional `system` instruction.
+- **conversation**: a list of `messages` (each with a `role` and `content`) is rendered through the chat template.
+
+When `transport` is omitted, the model's default is used: `chat` when the backend exposes a chat template, `raw`
+otherwise.
+
+## Interacting with the model
+
+### Buffered queries
+
+The simplest interaction is a buffered query: send a prompt, receive the full response once generation completes. Using
+the native dialect:
+
+```console
+curl --request POST \
+  --url http://127.0.0.1:8000/llm/query/ \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "transport": "chat",
+  "prompt": "What is Flama in one sentence?",
+  "system": "You are a concise assistant.",
+  "params": {"temperature": 0.7, "max_tokens": 128}
+}'
+```
+
+The response is an envelope with channel-tagged blocks. The user-visible answer arrives on the `output` channel, while
+reasoning, when present, arrives on a separate channel:
+
+```json
+{
+  "id": "0b9f1c2d-3e4a-5b6c-7d8e-9f0a1b2c3d4e",
+  "created": 1781679164,
+  "blocks": [
+    {
+      "type": "text",
+      "channel": "output",
+      "text": "Flama is a Python framework for building production-ready ML and LLM APIs with minimal code."
+    }
+  ],
+  "stop_reason": "stop",
+  "usage": {"input_tokens": 23, "output_tokens": 19}
+}
+```
+
+### Streaming responses
+
+For responsive, token-by-token output, the native dialect uses a two-step flow. First, create a generation with a
+<Label color="blue">POST</Label> to `/llm/stream/`; it returns a stream identifier and kicks off generation in the
+background:
+
+```console
+curl --request POST \
+  --url http://127.0.0.1:8000/llm/stream/ \
+  --header 'Content-Type: application/json' \
+  --data '{"transport": "chat", "prompt": "Explain dependency injection."}'
+
+{"id": "5b4a3c2d-1e0f-4a9b-8c7d-6e5f4a3b2c1d"}
+```
+
+Then consume the stream with a <Label color="green">GET</Label> to `/llm/stream/{id}/`, which returns
+`text/event-stream`. The two-step design lets browsers use a native `EventSource` (which only supports GET) and
+reconnect transparently with the `Last-Event-ID` header:
+
+```console
+curl --request GET \
+  --url http://127.0.0.1:8000/llm/stream/5b4a3c2d-1e0f-4a9b-8c7d-6e5f4a3b2c1d/ \
+  --header 'Accept: text/event-stream'
+
+event: message.start
+data: {"id": "5b4a3c2d-1e0f-4a9b-8c7d-6e5f4a3b2c1d"}
+
+event: block.delta
+data: {"channel": "output", "text": "Dependency injection is "}
+
+event: block.delta
+data: {"channel": "output", "text": "a pattern where ..."}
+
+event: message.stop
+data: {"stop_reason": "stop", "usage": {"input_tokens": 12, "output_tokens": 64}}
+```
+
+## Example
+
+Putting it together, here is a complete application that serves a single model across the native and OpenAI dialects with
+sensible generation defaults:
+
+```python
+# examples/serving_llms.py
+import flama
+from flama import Flama
+
+app = Flama(
+    openapi={
+        "info": {
+            "title": "Generative AI API",
+            "version": "1.0.0",
+            "description": "Serving large language models with Flama 🔥",
+        },
+    },
+    docs="/docs/",
+)
+
+app.models.add_model(
+    path="/llm/",
+    model="google_gemma-4-E2B-it.flm",
+    name="assistant",
+    serving=("native", "openai"),
+    params={"temperature": 0.7, "max_tokens": 512},
+)
+
+
+if __name__ == "__main__":
+    flama.run(flama_app=app, server_host="0.0.0.0", server_port=8000)
+```
+
+Run it with the CLI and explore the auto-generated documentation at `http://127.0.0.1:8000/docs/`:
+
+```console
+flama run examples.serving_llms:app
+
+INFO:     Started server process [42137]
+INFO:     Waiting for application startup.
+INFO:     Model starting (name: assistant)
+INFO:     Model ready (name: assistant)
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+```
+
+If you would rather serve a model without writing any code at all, the
+[serve](/docs/flama-cli/serve/) command does exactly this from the command line. In the
+[next page](/docs/generative-ai/chatbot-application/) we turn this bare API into an interactive chat application.

--- a/content/docs/6-Generative AI/4-Chatbot application.mdx
+++ b/content/docs/6-Generative AI/4-Chatbot application.mdx
@@ -1,0 +1,110 @@
+---
+title: Chatbot application
+wip: true
+---
+
+Serving a large language model (LLM) over HTTP is the foundation; talking to it through `curl` is not how most people
+want to interact with a model. <FlamaName /> ships a complete, ready-to-use chat interface as part of the native serving
+layer, so any model you serve comes with a polished web application out of the box, no frontend code required. This page
+covers the built-in chat interface, how to enable it, and the template it is built from.
+
+## What is the built-in chat interface?
+
+In <FlamaName />, the **chat interface** is a single-page web application served directly from your model's resource. It
+is part of the *native* serving dialect: when the native layer is enabled, the model exposes a
+<Label color="green">GET</Label> **/chat/** route that returns a self-contained HTML application wired to the model's
+streaming endpoint. Open it in a browser and you have a working chat client against your own model.
+
+**Why is it useful?**
+
+- **Zero frontend effort**: A production-quality chat UI ships with the framework; you do not write or build any
+  JavaScript.
+- **Rich rendering**: Responses render as Markdown, with LaTeX math (via [KaTeX](https://katex.org/)) and
+  [Mermaid](https://mermaid.js.org/) diagrams, so technical answers display the way they were meant to.
+- **Streaming and resumption**: The interface consumes the native Server-Sent Events (SSE) stream, displaying tokens as
+  they arrive and reconnecting transparently with `Last-Event-ID` if the connection drops.
+- **Self-contained**: The whole application is a single HTML file with no external runtime dependencies, so it works
+  behind a firewall and deploys wherever your API does.
+
+## Enabling the chat interface
+
+The chat interface is part of the native serving dialect, so you enable it by including `"native"` in the
+resource's `serving` tuple (it is included by default when `serving` is omitted):
+
+```python
+# examples/chatbot.py
+import flama
+from flama import Flama
+
+app = Flama(
+    openapi={
+        "info": {
+            "title": "Generative AI API",
+            "version": "1.0.0",
+            "description": "A chatbot powered by Flama 🔥",
+        },
+    },
+    docs="/docs/",
+)
+
+app.models.add_model(
+    path="/llm/",
+    model="google_gemma-4-E2B-it.flm",
+    name="assistant",
+    serving=("native",),
+)
+
+
+if __name__ == "__main__":
+    flama.run(flama_app=app, server_host="0.0.0.0", server_port=8000)
+```
+
+Run the application as usual:
+
+```console
+flama run examples.chatbot:app
+
+INFO:     Started server process [44021]
+INFO:     Waiting for application startup.
+INFO:     Model ready (name: assistant)
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+```
+
+## Using the chat interface
+
+With the application running, navigate to **http://127.0.0.1:8000/llm/chat/** in your browser. You are greeted with a
+chat window where you can type a prompt and watch the model's reply stream in token by token. Markdown formatting, code
+blocks, mathematical expressions, and diagrams are all rendered as the response arrives.
+
+Because the interface is mounted relative to the resource path, each model you serve gets its own chat window. If you
+register a second model under `/coder/`, its chat interface lives at `/coder/chat/`, talking to that model's own
+streaming endpoint.
+
+## How it works
+
+The chat interface is a thin client over the native streaming endpoints described in the
+[previous page](/docs/generative-ai/serving-llms/). When the page loads, it resolves the URL of the resource's
+`create_stream` endpoint and uses it to drive a two-step exchange for every message:
+
+1. A <Label color="blue">POST</Label> to **/llm/stream/** creates a generation and returns a stream identifier.
+2. A native `EventSource` connects to <Label color="green">GET</Label> `/llm/stream/{id}/` and renders each
+   `block.delta` event as it arrives, until the closing `message.stop` event.
+
+This is the same flow any custom frontend would use, which means the built-in interface is also a reference
+implementation: if you outgrow it, you can build your own client against exactly the same endpoints.
+
+## The chatbot template
+
+The interface is not a one-off HTML blob; it is produced from a proper frontend application, the **chatbot template**.
+The template is built with [pnpm](https://pnpm.io/) and the [`@vortico/ui`](https://www.npmjs.com/org/vortico) component
+library, and compiled into the single self-contained HTML file that <FlamaName /> ships and serves. It is responsible
+for the Markdown, LaTeX, and Mermaid rendering described above, and is organised in a per-application layout so it can be
+adapted to your own branding and behaviour.
+
+For most use cases the bundled interface is all you need, and it requires no build step on your part. If you want to
+customise it, the template gives you a modern, component-based starting point rather than forcing you to start from a
+blank page.
+
+In the [next page](/docs/generative-ai/model-context-protocol/) we move from serving a model to exposing tools,
+resources, and prompts to AI clients through the Model Context Protocol.

--- a/content/docs/6-Generative AI/5-Model Context Protocol.mdx
+++ b/content/docs/6-Generative AI/5-Model Context Protocol.mdx
@@ -1,0 +1,261 @@
+---
+title: Model Context Protocol
+wip: true
+---
+
+Serving a model is one half of the generative AI story; the other half is giving models access to *your* world, the
+functions they can call, the data they can read, and the prompts they can reuse. The **Model Context Protocol** (MCP) is
+the open standard for exactly that, and <FlamaName /> provides native, first-class support for building MCP servers.
+This page shows how to expose tools, resources, and prompts to AI clients, and how to use the advanced extensions for
+background tasks, interactive input, and embedded user interfaces.
+
+## What is the Model Context Protocol?
+
+The **Model Context Protocol** is an open standard that lets AI applications connect to external capabilities through a
+uniform interface. An **MCP server** advertises three kinds of capability: *tools* (functions the model can invoke),
+*resources* (data the model can read), and *prompts* (reusable prompt templates). Clients such as AI assistants discover
+these capabilities and call them over [JSON-RPC](https://www.jsonrpc.org/) (a lightweight remote-procedure-call protocol
+that exchanges JSON messages).
+
+In <FlamaName />, an MCP server is a registry you populate with decorated Python functions, and then mount on your
+application like any other route. The framework implements the **stateless `2026-07-28`** revision of the protocol:
+rather than negotiating a session once through an `initialize` handshake, every request is self-contained, carrying its
+protocol version and capabilities in a `_meta` object and its routing data in `Mcp-Method` / `Mcp-Name` headers. This
+makes MCP servers trivial to scale horizontally, since no per-client state is held between calls.
+
+**Why does it matter?**
+
+- **Interoperability**: Any MCP-capable client can use your tools without bespoke integration code.
+- **Reuse**: The same Python functions that power your API can be exposed to AI agents with a single decorator.
+- **Type safety**: <FlamaName /> derives each tool's input and output JSON Schema from the handler's type hints, so
+  clients receive accurate, self-contained contracts.
+- **Statelessness**: The `2026-07-28` protocol holds no session state, so servers scale horizontally without sticky
+  sessions.
+- **Extensibility**: Optional extensions add background Tasks, interactive Elicitation, and embeddable MCP Apps user
+  interfaces.
+
+## Creating an MCP server
+
+An MCP server is an instance of `MCPServer`. You register tools on it with the `tool` decorator; <FlamaName /> infers
+each tool's input schema from the handler's type hints:
+
+```python
+from flama.mcp.server import MCPServer
+
+tools_server = MCPServer("tools", version="2.0.0", instructions="Flama demo MCP tools server")
+
+
+@tools_server.tool("add", description="Add two integers")
+def add(a: int, b: int) -> int:
+    return a + b
+
+
+@tools_server.tool(description="Greet someone by name")
+async def greet(name: str) -> str:
+    return f"Hello, {name}!"
+```
+
+Tools may be synchronous or asynchronous functions. When you omit the name, the function's own name is used; when you
+omit the description, its docstring is used. The parameters and return annotation become the tool's `inputSchema` and
+`outputSchema`, advertised to clients verbatim.
+
+## Mounting servers
+
+A server becomes reachable once you mount it on the application through the `mcp` module. Each server is mounted at its
+own path, and a single application can host several:
+
+```python
+app.mcp.add_server("/mcp/tools/", "tools", server=tools_server)
+app.mcp.add_server("/mcp/math/", "math", server=math_server)
+```
+
+If you do not have a pre-built server, `add_server` can construct one for you from keyword arguments
+(`version`, `instructions`, and so on); pass `server=` only when you have already populated a server instance.
+
+## Calling a tool
+
+Clients interact with a mounted server by POSTing a JSON-RPC request to its path, with the routing headers that identify
+the method and target. To invoke the `add` tool defined above:
+
+```console
+curl --request POST \
+  --url http://127.0.0.1:8000/mcp/tools/ \
+  --header 'Content-Type: application/json' \
+  --header 'Mcp-Method: tools/call' \
+  --header 'Mcp-Name: add' \
+  --header 'MCP-Protocol-Version: 2026-07-28' \
+  --data '{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {"name": "add", "arguments": {"a": 2, "b": 3}}
+}'
+```
+
+The server replies with a JSON-RPC result carrying the rendered content and, because `add` declares a return type, a
+structured representation of the result:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "content": [{"type": "text", "text": "5"}],
+    "structuredContent": 5
+  }
+}
+```
+
+Clients discover the available tools the same way, by sending a `tools/list` method, so an AI assistant can enumerate
+your capabilities before deciding which to call.
+
+## Resources and prompts
+
+Beyond tools, a server can expose **resources** (readable data, addressed by a URI) and **prompts** (named, reusable
+prompt templates). Both use the same decorator style:
+
+```python
+import json
+
+
+@tools_server.resource("config://app", name="config", description="Application configuration",
+                       mime_type="application/json")
+def config():
+    return json.dumps({"debug": True, "name": "flama-mcp"})
+
+
+@tools_server.prompt("summarise", description="Summarise the given text")
+def summarise(text: str):
+    return f"Summarise the following:\n\n{text}"
+```
+
+Resources are listed and read by their URI; prompts are listed by name and rendered with arguments supplied by the
+client.
+
+## Advanced extensions
+
+The `2026-07-28` protocol defines optional extensions, all supported natively. A server advertises the extensions it
+uses in its discovery capabilities, so clients negotiate them per request.
+
+### Tasks
+
+Long-running tools can run as background **Tasks** rather than blocking the call. Pass `task=True` and the server returns
+a task handle the client can poll:
+
+```python
+@tools_server.tool("square", task=True, description="Square a number as a background task")
+async def square(x: int) -> int:
+    return x * x
+```
+
+### Elicitation
+
+A tool can pause mid-call to **elicit** further input from the user. The handler declares a parameter annotated with
+`Elicitation` to read the answers gathered so far, and returns `Elicit.require(...)` to request more:
+
+```python
+from flama.mcp.data_structures import Elicit, Elicitation
+
+
+@tools_server.tool("confirm", description="Confirm an action through an elicitation round-trip")
+def confirm(elicitation: Elicitation) -> str:
+    if "confirm" not in elicitation:
+        return Elicit.require("Are you sure?", {"type": "boolean"}, name="confirm")
+    return f"confirmed={elicitation['confirm']}"
+```
+
+The `elicitation` parameter is supplied by the server and excluded from the tool's input schema, so it never appears as
+a tool argument. Because the protocol is stateless, the answers gathered so far are round-tripped through an opaque
+continuation token the client echoes back on the retry.
+
+### MCP Apps
+
+A tool can declare a prefetchable user-interface template (an **MCP App**) that hosts render alongside its result.
+Register the template with `app_template` and point the tool at it with `ui_template`:
+
+```python
+@tools_server.app_template("ui://widget", name="widget", description="A small UI widget")
+def widget():
+    return "<html><body><h1>Flama widget</h1></body></html>"
+
+
+@tools_server.tool("with_ui", description="A tool that declares a prefetchable UI template", ui_template="ui://widget")
+def with_ui() -> str:
+    return "rendered"
+```
+
+## Example
+
+The following application assembles a tools server with a synchronous tool, an async tool, a background task, an
+elicitation round-trip, a resource, and a prompt, plus a second server mounted on the same application:
+
+```python
+# examples/mcp.py
+import json
+
+import flama
+from flama import Flama
+from flama.mcp.data_structures import Elicit, Elicitation
+from flama.mcp.server import MCPServer
+
+tools_server = MCPServer("tools", version="2.0.0", instructions="Flama demo MCP tools server")
+
+
+@tools_server.tool("add", description="Add two integers")
+def add(a: int, b: int) -> int:
+    return a + b
+
+
+@tools_server.tool("square", task=True, description="Square a number as a background task")
+async def square(x: int) -> int:
+    return x * x
+
+
+@tools_server.tool("confirm", description="Confirm an action through an elicitation round-trip")
+def confirm(elicitation: Elicitation) -> str:
+    if "confirm" not in elicitation:
+        return Elicit.require("Are you sure?", {"type": "boolean"}, name="confirm")
+    return f"confirmed={elicitation['confirm']}"
+
+
+@tools_server.resource("config://app", name="config", description="Application configuration",
+                       mime_type="application/json")
+def config():
+    return json.dumps({"debug": True, "name": "flama-mcp"})
+
+
+@tools_server.prompt("summarise", description="Summarise the given text")
+def summarise(text: str):
+    return f"Summarise the following:\n\n{text}"
+
+
+math_server = MCPServer("math", version="2.0.0")
+
+
+@math_server.tool("multiply", description="Multiply two integers")
+def multiply(a: int, b: int) -> int:
+    return a * b
+
+
+app = Flama(
+    openapi={
+        "info": {
+            "title": "Generative AI API",
+            "version": "1.0.0",
+            "description": "Model Context Protocol servers with Flama 🔥",
+        },
+    },
+)
+
+app.mcp.add_server("/mcp/tools/", "tools", server=tools_server)
+app.mcp.add_server("/mcp/math/", "math", server=math_server)
+
+
+if __name__ == "__main__":
+    flama.run(flama_app=app, server_host="0.0.0.0", server_port=8000)
+```
+
+With this, your application serves models, a chat interface, and a set of agent-ready tools from a single codebase. To
+revisit how those models are served, return to [Serving LLMs](/docs/generative-ai/serving-llms/); to learn how
+<FlamaName /> structures larger applications, continue to the
+[Domain-driven design](/docs/domain-driven-design/introduction/) section.

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -145,7 +145,7 @@ function DocsDashboard() {
               <strong>Model Context Protocol</strong>.
             </>
           }
-          url="/docs/generative-ai/introduction/"
+          url="/docs/generative-ai/overview/"
         />
         <DocsDashboardItem
           icon={<IconTopologyStar3 className="h-full w-full" />}


### PR DESCRIPTION
## Summary

- Add the new Generative AI documentation section: Introduction, Getting models, Serving LLMs, Chatbot application, and Model Context Protocol.
- Pages are flagged `wip: true` for a later manual review pass.

## Test plan

- [x] `npm run build` passes
- [x] Section appears in the docs navigation under Generative AI
- [x] Cross-links to Predictive AI and CLI resolve

Closes #12