### PR TITLE
Flama CLI documentation updates for 2.0

### DIFF
--- a/content/docs/4-Flama CLI/2-Serve.mdx
+++ b/content/docs/4-Flama CLI/2-Serve.mdx
@@ -1,38 +1,41 @@
 ---
 title: Serve
-wip: false
+wip: true
 ---
 
-## Serve machine-learning models
+## Serve models without writing an app
 
-In the previous section we have introduced the command **run** of <FlamaName /> CLI. The **run** command allowed us to
-serve any <FlamaName /> app, being possible to adapt the configuration of the app using the standard **uvicorn**
-arguments. But this is not the end of the story.
+In the previous section we introduced the **run** command of the <FlamaName /> CLI, which serves any <FlamaName /> app
+you have written. The **serve** command comes to the rescue of those who want an instantaneous deployment of one or more
+models without writing a single line of code. It builds the application for you and exposes the models you point it at,
+whether they are traditional predictive models or generative models.
 
-The command **serve** comes to the rescue of those who are looking for an instantaneous serving of an ML model without
-having to write an app. This command, as we are about to see, only requires the ML model to be served. The model will
-have to be saved as a binary file beforehand by using the tools offered by <FlamaName />. The details about how to
-properly save the models can be found in the section [packaging models](/docs/machine-learning-api/packaging-models/).
+Models must be packaged as binary **.flm** files beforehand. For predictive models, see
+[packaging models](/docs/predictive-ai/packaging-models/); for generative models, see
+[getting models](/docs/generative-ai/getting-models/).
 
 ### Example files
 
-The best way of seeing the power of **serve** is by example. Although we have not yet seen how to produce the ML file
-needed (go to [packaging models](/docs/machine-learning-api/packaging-models/) to learn how), we can use any of the
-following example files for the sake of learning:
+The best way to see the power of **serve** is by example. You can use any of the following predictive example files:
 
 - [Scikit Learn model](/models/sklearn_model.flm)
 - [TensorFlow model](/models/tensorflow_model.flm)
 - [PyTorch model](/models/pytorch_model.flm)
 
-Once you have downloaded any of the files listed above, you will be able to serve your first ML model codeless.
+For generative serving, fetch a small generative model:
+
+```console
+flama get --source huggingface --family llm google/gemma-4-E2B-it
+```
+
+This produces a `google_gemma-4-E2B-it.flm` artifact.
 
 ## Codeless serving
 
-Let's pick up one of the example model files we have just introduced in the previous section, say **sklearn_model.flm**.
-Now, let's run:
+Every model is declared with a `--model` option. In its simplest form, you pass the path to a `.flm` file:
 
 ```console
-flama serve sklearn_model.flm
+flama serve --model sklearn_model.flm
 
 INFO:     Started server process [15822]
 INFO:     Waiting for application startup.
@@ -40,334 +43,182 @@ INFO:     Application startup complete.
 INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
 ```
 
-Does it seem familiar? Yup, indeed, as you can see we have a <FlamaName /> app up and running on **http://127.0.0.1**
-and listening via the port **8000**. But, this time we have not written a single line of code! This is the **codeless
-approach** of <FlamaName /> to ML models deployment, which makes possible the deployment of an already trained-tested ML
-model as an API ready to receive requests and return estimations almost without any effort.
+Does it seem familiar? Indeed, we have a <FlamaName /> app up and running on **http://127.0.0.1** listening on port
+**8000**, without having written a single line of code. This is the **codeless approach** of <FlamaName /> to model
+deployment, which makes it possible to expose an already trained model as an API ready to receive requests almost without
+any effort.
 
-### How do we interact with the model?
+### The `--model` specification
 
-So, we have an app which is running an ML model. The natural question to ask now is, how do we interact with that model?
-All models served with **flama serve** come with the following endpoints for free:
-
-- <Label color="green">GET</Label> **http://127.0.0.1:8000/docs/**: Returns an interactive HTML documentation which
-  allows us to interact with the model in our web browser. This is the recommended way to start interacting with the
-  model, as it informs us about all the routes available, and helps us to figure how to programmatically interact with
-  all other routes.
-- <Label color="green">GET</Label> **http://127.0.0.1:8000/schema/**: Returns a JSON which represents the model being
-  served.
-- <Label color="blue">POST</Label> **http://127.0.0.1:8000/predict/** Expects the input data (observations) to be passed
-  as argument to predict their output.
-
-### Interactive and intuitive documentation
-
-As mentioned in the previous section, we recommend inspecting the documentation route (`/docs/`) as soon as we have the
-model serving. To do that you only need to **flama serve** whatever model which you have packaged previously, and you'll
-get something like:
-
-<img src="/images/docs/docs-schema-get.png" alt="docs-get-schema" width="1600" />
-
-As you can see, the documentation page not only gives you a handy way to interact with the different endpoints
-available, but also gives you the equivalent `curl` statement. For instance, in order to get the schema of the model:
+The bare path is shorthand. The full form of `--model` is a comma-separated list of `key=value` pairs that configure how
+each model is mounted:
 
 ```console
-curl --request GET \
-  --url http://127.0.0.1:8000/ \
-  --header 'Content-Type: application/json'
+flama serve --model file=model.flm,url=/route,name=my-model
+```
 
+The keys are:
+
+- **file** (required): the path to the `.flm` artifact.
+- **url**: the route under which the model is served (default: `/`).
+- **name**: the model name, used for documentation (default: `model`).
+- **serving**: for generative models, a colon-separated list of serving dialects, e.g. `serving=native:openai` (see
+  [serving generative models](/docs/generative-ai/serving-llms/)).
+- **params**: for generative models, a colon-separated list of generation defaults, e.g.
+  `params=temperature=0.7:max_tokens=200`.
+- **channel_scanner**, **tool_scanner**, **tool_parser**: advanced decoder controls for generative models, defaulting to
+  auto-detection.
+
+### Serving a predictive model
+
+To serve a predictive model under a named route, point `--model` at its artifact and choose a URL and name:
+
+```console
+flama serve --model file=sklearn_model.flm,url=/xor,name=xor-classifier
+
+INFO:     Started server process [15999]
+INFO:     Waiting for application startup.
+INFO:     Model ready (name: xor-classifier)
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+```
+
+The model is now reachable under `/xor/`, exposing the prediction and documentation endpoints described in
+[how do we interact with the model?](#how-do-we-interact-with-the-model).
+
+### Serving a generative model
+
+Serving a generative model is the same command with a generative model artifact and a choice of dialects. The following
+exposes the model under `/llm/` with both the native and OpenAI-compatible dialects, and a default sampling temperature:
+
+```console
+flama serve --model file=google_gemma-4-E2B-it.flm,url=/llm,name=assistant,serving=native:openai,params=temperature=0.7
+
+INFO:     Started server process [15999]
+INFO:     Waiting for application startup.
+INFO:     Model ready (name: assistant)
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+```
+
+The model is now reachable through the native endpoints (including the chat interface at `/llm/chat/`) and the
+OpenAI-compatible endpoints under `/llm/openai/v1/`. See [serving generative models](/docs/generative-ai/serving-llms/)
+for the full route map.
+
+### Serving multiple models
+
+The `--model` option is repeatable, so a single command can serve several models at once, each on its own route:
+
+```console
+flama serve \
+  --model file=sklearn_model.flm,url=/sklearn,name=logistic-regression \
+  --model file=pytorch_model.flm,url=/pytorch,name=pytorch-model
+```
+
+### Specification files
+
+For anything beyond a couple of inline options, a whole model specification can be loaded from a JSON, YAML, or TOML file
+with the `@` prefix:
+
+```json
+// assistant.json
 {
-  "meta": {
-    "id": "cb659dec-ca09-40f8-a804-63c1f89113f6",
-    "timestamp": "2025-04-03T19:25:40.856195",
-    "framework": {
-      "lib": "sklearn",
-      "version": "1.8.0"
-    },
-    "model": {
-      "obj": "MLPClassifier",
-      "info": {
-        "activation": "tanh",
-        "alpha": 0.0001,
-        "batch_size": "auto",
-        "beta_1": 0.9,
-        "beta_2": 0.999,
-        "early_stopping": false,
-        "epsilon": 1e-8,
-        "hidden_layer_sizes": [
-          10
-        ],
-        "learning_rate": "constant",
-        "learning_rate_init": 0.001,
-        "max_fun": 15000,
-        "max_iter": 2000,
-        "momentum": 0.9,
-        "n_iter_no_change": 10,
-        "nesterovs_momentum": true,
-        "power_t": 0.5,
-        "random_state": 0,
-        "shuffle": true,
-        "solver": "adam",
-        "tol": 0.0001,
-        "validation_fraction": 0.1,
-        "verbose": false,
-        "warm_start": false
-      },
-      "params": {
-        "solver": "adam"
-      },
-      "metrics": {
-        "recall": "0.95"
-      }
-    },
-    "extra": {
-      "model_version": "1.0.0",
-      "model_description": "This is a test model",
-      "model_author": "John Doe",
-      "model_license": "MIT",
-      "tags": [
-        "test",
-        "example"
-      ]
-    }
-  },
-  "artifacts": {
-    "foo.json": "/var/folders/.../artifacts/foo.json"
-  }
+  "file": "google_gemma-4-E2B-it.flm",
+  "url": "/llm",
+  "name": "assistant",
+  "serving": ["native", "openai"],
+  "params": {"temperature": 0.7, "max_tokens": 512}
 }
 ```
 
-Or, in case we want to make a prediction:
+With the specification saved, pass it to **serve** with the `@` prefix:
 
-<img src="/images/docs/docs-predict-post.png" alt="docs-post-predict" width="1600" />
+```console
+flama serve --model @assistant.json
+```
+
+## How do we interact with the model?
+
+All predictive models served with **flama serve** come with the following endpoints for free:
+
+- <Label color="green">GET</Label> **http://127.0.0.1:8000/docs/**: An interactive HTML documentation page to explore
+  and call every route in the browser. This is the recommended starting point.
+- <Label color="green">GET</Label> **http://127.0.0.1:8000/schema/**: The OpenAPI schema describing the served API.
+- <Label color="blue">POST</Label> **http://127.0.0.1:8000/predict/**: Expects the input data (observations) to be
+  passed as argument to predict their output.
+
+For a prediction against a predictive model served at the default route:
 
 ```console
 curl --request POST \
   --url http://127.0.0.1:8000/predict/ \
   --header 'Content-Type: application/json' \
-  --data '{
-  "input": [
-    [0, 0], [1, 0], [0, 1], [0, 0]
-  ]
-}'
+  --data '{"input": [[0, 0], [1, 0], [0, 1], [0, 0]]}'
 
-{
-  "output": [
-    0,
-    1,
-    1,
-    0
-  ]
-}
+{"output": [0, 1, 1, 0]}
 ```
 
-🥳 Awesome! Now, not only you have your model serving, but you also made predictions by interacting with it
-programmatically. The cool thing about this, is that this way of interacting with your model via _requests_ is the same,
-no matter where the model is deployed. And, this is a huge step towards the productionalization of your model. Now, we
-have a reproducible problem, which is key to understand and replicate the behaviour of our models in a production
-environment, since it'll be the same as we observe in local.
+Generative models served with **serve** expose the dialect endpoints described in the
+[Generative AI](/docs/generative-ai/serving-llms/) section instead.
 
 ## Parameters
 
-Although the default usage of **flama serve** is already very convenient, you might be interested in customise a bit the
-result. For instance, you might want to serve the model at a different route (i.e., not at the default **/**), or the
-name of the model (i.e., not **model**), and so on. Such a customisation is possible thanks to the different optional
-inputs of the CLI:
+Beyond `--model`, the **serve** command accepts application and server parameters. To inspect them all, run:
 
 ```console
 flama serve --help
-
-Usage: flama serve [OPTIONS] MODEL_PATH
-
-  Serve an ML model file within a Flama Application.
-
-  Serve the ML model file specified by <MODEL_PATH> within a Flama
-  Application.
-
-Options:
-  --model-url TEXT                Route of the model  [default: /]
-  --model-name TEXT               Name of the model  [default: model]
-  --app-debug BOOLEAN             Debug mode  [default: False]
-  --app-title TEXT                Name of the application  [default: Flama]
-  --app-version TEXT              Version of the application  [default: 0.1.0]
-  --app-description TEXT          Description of the application  [default:
-                                  Fire up with the flame]
-  --app-schema TEXT               Route of the application schema  [default:
-                                  /schema/]
-  --app-docs TEXT                 Route of the application documentation
-                                  [default: /docs/]
-  --server-host TEXT              Bind socket to this host.  [default:
-                                  127.0.0.1]
-  --server-port INTEGER           Bind socket to this port.  [default: 8000]
-  --server-reload                 Enable auto-reload.
-  --server-uds TEXT               Bind to a UNIX domain socket.
-  --server-fd INTEGER             Bind to socket from this file descriptor.
-  --server-reload-dirs PATH       Set reload directories explicitly, instead
-                                  of using the current working directory.
-  --server-reload-includes TEXT   Set glob patterns to include while watching
-                                  for files. Includes '*.py' by default; these
-                                  defaults can be overridden with `--server-
-                                  reload-exclude`. This option has no effect
-                                  unless watchfiles is installed.
-  --server-reload-excludes TEXT   Set glob patterns to exclude while watching
-                                  for files. Includes '.*, .py[cod], .sw.*,
-                                  ~*' by default; these defaults can be
-                                  overridden with `--server-reload-include`.
-                                  This option has no effect unless watchfiles
-                                  is installed.
-  --server-reload-delay FLOAT     Delay between previous and next check if
-                                  application needs to be. Defaults to 0.25s.
-                                  [default: 0.25]
-  --server-workers INTEGER        Number of worker processes. Defaults to the
-                                  $WEB_CONCURRENCY environment variable if
-                                  available, or 1. Not valid with --server-
-                                  dev.
-  --server-loop [auto|asyncio|uvloop]
-                                  Event loop implementation.  [default: auto]
-  --server-http [auto|h11|httptools]
-                                  HTTP protocol implementation.  [default:
-                                  auto]
-  --server-ws [auto|none|websockets|wsproto]
-                                  WebSocket protocol implementation.
-                                  [default: auto]
-  --server-ws-max-size INTEGER    WebSocket max size message in bytes
-                                  [default: 16777216]
-  --server-ws-ping-interval FLOAT
-                                  WebSocket ping interval  [default: 20.0]
-  --server-ws-ping-timeout FLOAT  WebSocket ping timeout  [default: 20.0]
-  --server-ws-per-message-deflate BOOLEAN
-                                  WebSocket per-message-deflate compression
-                                  [default: True]
-  --server-lifespan [auto|on|off]
-                                  Lifespan implementation.  [default: auto]
-  --server-interface [auto|asgi3|asgi2|wsgi]
-                                  Select ASGI3, ASGI2, or WSGI as the
-                                  application interface.  [default: auto]
-  --server-env-file PATH          Environment configuration file.
-  --server-log-config PATH        Logging configuration file. Supported
-                                  formats: .ini, .json, .yaml.
-  --server-log-level [critical|error|warning|info|debug|trace]
-                                  Log level. [default: info]
-  --server-access-log / --server-no-access-log
-                                  Enable/Disable access log.
-  --server-use-colors / --server-no-use-colors
-                                  Enable/Disable colorized logging.
-  --server-proxy-headers / --server-no-proxy-headers
-                                  Enable/Disable X-Forwarded-Proto,
-                                  X-Forwarded-For, X-Forwarded-Port to
-                                  populate remote address info.
-  --server-server-header / --server-no-server-header
-                                  Enable/Disable default Server header.
-  --server-date-header / --server-no-date-header
-                                  Enable/Disable default Date header.
-  --server-forwarded-allow-ips TEXT
-                                  Comma separated list of IPs to trust with
-                                  proxy headers. Defaults to the
-                                  $FORWARDED_ALLOW_IPS environment variable if
-                                  available, or '127.0.0.1'.
-  --server-root-path TEXT         Set the ASGI 'root_path' for applications
-                                  submounted below a given URL path.
-  --server-limit-concurrency INTEGER
-                                  Maximum number of concurrent connections or
-                                  tasks to allow, before issuing HTTP 503
-                                  responses.
-  --server-backlog INTEGER        Maximum number of connections to hold in
-                                  backlog
-  --server-limit-max-requests INTEGER
-                                  Maximum number of requests to service before
-                                  terminating the process.
-  --server-timeout-keep-alive INTEGER
-                                  Close Keep-Alive connections if no new data
-                                  is received within this timeout.  [default:
-                                  5]
-  --server-ssl-keyfile TEXT       SSL key file
-  --server-ssl-certfile TEXT      SSL certificate file
-  --server-ssl-keyfile-password TEXT
-                                  SSL keyfile password
-  --server-ssl-version INTEGER    SSL version to use (see stdlib ssl module's)
-                                  [default: 17]
-  --server-ssl-cert-reqs INTEGER  Whether client certificate is required (see
-                                  stdlib ssl module's)  [default: 0]
-  --server-ssl-ca-certs TEXT      CA certificates file
-  --server-ssl-ciphers TEXT       Ciphers to use (see stdlib ssl module's)
-                                  [default: TLSv1]
-  --server-headers TEXT           Specify custom default HTTP response headers
-                                  as a Name:Value pair
-  --server-app-dir TEXT           Look for APP in the specified directory, by
-                                  adding this to the PYTHONPATH. Defaults to
-                                  the current working directory.  [default: .]
-  --server-h11-max-incomplete-event-size INTEGER
-                                  For h11, the maximum number of bytes to
-                                  buffer of an incomplete event.
-  --server-factory                Treat APP as an application factory, i.e. a
-                                  () -> <ASGI app> callable.
-  --help                          Show this message and exit.
 ```
-
-We can readily see the following groups of parameters:
-
-### Model parameters
-
-- **model-url**: Route of the model (default: /)
-- **model-name**: Name of the model (default: model)
 
 ### App parameters
 
-- **app-debug**: Enable debug mode (default: False)
-- **app-title**: Name of the application (default: Flama)
-- **app-version**: Version of the application (default: 0.1.0)
-- **app-description**: Description of the application (default: Fire up) with the flame]
-- **app-docs**: Description of the application (default: Fire up) with the flame]
-- **app-schema**: Description of the application (default: Fire up) with the flame]
+- **app-debug**: enable debug mode (default: False).
+- **app-title**: name of the application (default: Flama).
+- **app-version**: version of the application (default: 0.1.0).
+- **app-description**: description of the application.
+- **app-docs**: route of the application documentation (default: `/docs/`).
+- **app-schema**: route of the application schema (default: `/schema/`).
 
-The parameter **app-debug** brings with it useful tools which make the debugging of the code easier,
-e.g. highly-detailed error messages, and interactive error webpages.
+The parameter **app-debug** brings useful tools that make debugging easier, e.g. highly-detailed error messages and
+interactive error webpages.
 
 ### Server parameters
 
 All [uvicorn options](https://www.uvicorn.org/settings/) can be passed to the command **serve** with the format
-`server-<UVICORN_OPTION_NAME>`, as we discussed for the command [run](/docs/flama-cli/run/), e.g.:
+`server-<UVICORN_OPTION_NAME>`, as discussed for the command [run](/docs/flama-cli/run/), e.g.:
 
-- **server-host**: Bind socket to this host (default: 127.0.0.1)
-- **server-port**: Bind socket to this port (default: 8000)
+- **server-host**: bind socket to this host (default: 127.0.0.1).
+- **server-port**: bind socket to this port (default: 8000).
 
 ### How to use parameters
 
-Each of the previous parameters can be directly passed to the CLI by using either `--<option-name> <value>`, or by
-utilising the equivalent environment variable. The equivalent environment variable of any option will be named
-`FLAMA_<OPTION_NAME>=<VALUE>` (take care, the equivalent environment variable needs to have the prefix **FLAMA**, and
-written in capital letters, and underscored). For instance, if we want to change the route where the model is served we
-can do it by any of the following two equivalent ways:
-
-#### Using option argument
+Each parameter can be passed with `--<option-name> <value>` or via the equivalent environment variable, named
+`FLAMA_<OPTION_NAME>` (uppercase, underscored). For instance, to change the host:
 
 ```console
-flama serve sklearn_model.flm --model-url=/xor
+flama serve --model sklearn_model.flm --server-host=0.0.0.0
 ```
 
-#### Using environment variable
+or, equivalently:
 
 ```console
-export FLAMA_MODEL_PATH=sklearn_model.flm
-export FLAMA_MODEL_URL=/xor
-flama serve sklearn_model.flm
+export FLAMA_SERVER_HOST=0.0.0.0
+flama serve --model sklearn_model.flm
 ```
 
 ## Example
 
-As a quick usage example which populates all application and models parameters, we can run the following command line:
+As a quick example populating application and model parameters, we can run:
 
 ```console
-flama serve sklearn_model.flm \
-    --model-url="/xor" \
-    --model-name="XOR dummy model" \
-    --app-debug \
-    --app-title="ML API" \
-    --app-version="1.0.0" \
-    --app-description="XOR model serving for predictions" \
-    --app-docs="/docs/" \
-    --app-schema="/schema/"
+flama serve \
+  --model file=sklearn_model.flm,url=/xor,name="XOR dummy model" \
+  --app-debug \
+  --app-title="Predictive AI API" \
+  --app-version="1.0.0" \
+  --app-description="XOR model serving for predictions" \
+  --app-docs="/docs/" \
+  --app-schema="/schema/"
 ```
 
-With these changes, the documentation at **http://127.0.0.1:8000/docs/** will look like:
-
-<img src="/images/docs/docs-serve-params.png" alt="docs-post-predict" width="1600" />
+With these changes, the documentation at **http://127.0.0.1:8000/docs/** reflects the customised application metadata and
+serves the model at `/xor/`.

--- a/content/docs/4-Flama CLI/4-Model.mdx
+++ b/content/docs/4-Flama CLI/4-Model.mdx
@@ -1,209 +1,176 @@
 ---
 title: Model
-wip: false
+wip: true
 ---
 
 ## Serverless interaction
 
-We've discussed how to serve models as APIs with which we can interact
-with via HTTP requests. However, it might be the case that we want to interact with
-the model directly without the overhead of a server, e.g.:
+We have discussed how to serve models as APIs that we interact with over HTTP requests. However, it might be the case
+that we want to interact with a model directly without the overhead of a server, e.g.:
 
-- **Development & testing**: We are working with a model locally and want to try it out on some data to
-  quickly see whether everything is working as expected. This is typically what happens
-  when we're in the development stage of the ML lifecycle.
+- **Development and testing**: We are working with a model locally and want to try it out on some data to quickly check
+  everything behaves as expected. This is typical during the development stage of the model lifecycle.
 
-- **Streaming workflow**: This is also the case when we want to use a model as part of a larger pipeline
-  where the model acts as a data processor in a stream of data, in which case we want to be able to pipe data
-  into the model and get the output back.
+- **Streaming workflow**: We want to use a model as part of a larger pipeline where it acts as a data processor in a
+  stream, piping data in and getting output back.
 
-It is then clear that we need a different way to make use of the model than the
-client-server approach we've discussed so far.
+It is then clear that we need a different way to make use of a model than the client-server approach discussed so far.
 
-The command **model** allows us to interact with models directly from the command line
-without the need for a server. To inspect the command options, run:
+The command **model** lets us interact with models directly from the command line, with no server. It works with both
+traditional predictive models and generative models; the artifact family recorded in the `.flm` manifest is
+dispatched accordingly. To inspect the command options, run:
 
 ```console
 flama model --help
 
-Usage: flama model [OPTIONS] MODEL_PATH COMMAND [ARGS]...
+Usage: flama model [OPTIONS] FLAMA_MODEL_PATH COMMAND [ARGS]...
 
-  Interact with an ML model without server.
+  Interact with a packaged model without server.
 
-  This command is used to directly interact with an ML model without the need
-  of a server. This command can be used to perform any operation that is
-  supported by the model, such as inspect, or predict. <FLAMA_MODEL_PATH> is
-  the path of the model to be used, e.g. 'path/to/model.flm'. This can be
-  passed directly as argument of the command line, or by environment variable.
+  Works with both traditional ML models and large language models. <FLAMA_MODEL_PATH>
+  is the path of the model to be used, e.g. 'path/to/model.flm'.
 
 Options:
-  --help  Show this message and exit.
+  --channel-scanner DECODER_REF  Channel scanner format (LLM-only).
+  --tool-scanner DECODER_REF     Tool scanner format (LLM-only).
+  --tool-parser DECODER_REF      Tool body parser (LLM-only).
+  --help                         Show this message and exit.
 
 Commands:
-  inspect  Inspect an ML model.
-  predict  Make a prediction using an ML model.
+  inspect  Inspect a model artifact.
+  run      Run a one-shot inference.
+  stream   Stream output from a model.
 ```
+
+The `--channel-scanner`, `--tool-scanner`, and `--tool-parser` options are decoder controls for generative models; they
+default to auto-detection and are rejected for predictive models.
+
+## Sub-commands
+
+The **model** command exposes three sub-commands, each operating on a packaged `.flm` artifact: **inspect** reads its
+metadata without loading the weights, while **run** and **stream** perform inference.
 
 ### Inspect
 
-The sub-command **inspect** allows us to get access to the model metadata,
-as well as the list of artifacts packaged with the model, in a human-readable
-format. To access the documentation of the command, run:
+The sub-command **inspect** gives us access to the model metadata and the list of bundled artifacts, without loading the
+model:
 
 ```console
 flama model path/to/model.flm inspect --help
 
 Usage: flama model FLAMA_MODEL_PATH inspect [OPTIONS]
 
-  Inspect an ML model.
-
-  This command is used to inspect an ML model without the need of a server.
-  This command can be used to extract the ML model metadata, including the ID,
-  time when the model was created, information of the framework, and the model
-  info; and the list of artifacts packaged with the model.
+  Inspect a model artifact.
 
 Options:
   -p, --pretty  Pretty print the model inspection.
   --help        Show this message and exit.
 ```
 
-### Predict
+### Run
 
-The sub-command **predict** allows us to make predictions using the model. To access
-the documentation of the command, run:
+The sub-command **run** performs a one-shot inference. For predictive models, the input is a JSON list of feature
+vectors and the output is a JSON list of predictions. For generative models, the input is a prompt and the output is the
+generated response:
 
 ```console
-flama model path/to/model.flm predict --help
+flama model path/to/model.flm run --help
 
-Usage: flama model FLAMA_MODEL_PATH predict [OPTIONS]
+Usage: flama model FLAMA_MODEL_PATH run [OPTIONS]
 
-  Make a prediction using an ML model.
-
-  This command is used to make a prediction using an ML model without the need
-  of a server. It can be used for batch predictions, so both input and output
-  arguments must be json files containing a list of input values, each input
-  value being a list of values associated to the input of the model. The
-  output will be the list of predictions associated to the input, with each
-  prediction being a list of values representing the output of the model.
-
-  Example:
-
-  - input.json: [[0, 0], [0, 1], [1, 0], [1, 1]]
-
-  - output.json: [[0], [1], [1], [0]]
+  Run a one-shot inference.
 
 Options:
-  -f, --file FILENAME    File to be used as input for the model prediction in
-                         JSON format. (default: stdin).
-  -o, --output FILENAME  File to be used as output for the model prediction in
-                         JSON format. (default: stdout).
-  -p, --pretty           Pretty print the model prediction.
+  -i, --input FILENAME   Input file to read from (defaults to stdin).
+  --transport [raw|chat|conversation]
+                         LLM input shape. Defaults to the model's default.
+  --system TEXT          LLM system instruction (chat transport only).
+  --param TEXT           Generation parameter as key=value (LLM only, repeatable).
+  -o, --output FILENAME  File to be used as output (default: stdout).
+  -p, --pretty           Pretty print the output.
+  --channel TEXT         Channel(s) to include in output (LLM only, repeatable).
   --help                 Show this message and exit.
 ```
 
-## Examples
+### Stream
 
-To illustrate the usage of the **model** command, we'll use one of the models introduced
-before in the [Serve](/docs/flama-cli/serve/#example-files) section, e.g. the **SciKit-Learn** model.
+The sub-command **stream** emits output incrementally. For predictive models, the model emits one output per input item;
+for generative models, it emits the response one block at a time:
+
+```console
+flama model path/to/model.flm stream --help
+
+Usage: flama model FLAMA_MODEL_PATH stream [OPTIONS]
+
+  Stream output from a model.
+
+Options:
+  -i, --input FILENAME   Input file to read from (defaults to stdin).
+  --transport [raw|chat|conversation]
+                         LLM input shape. Defaults to the model's default.
+  --system TEXT          LLM system instruction (chat transport only).
+  --param TEXT           Generation parameter as key=value (LLM only, repeatable).
+  -o, --output FILENAME  File to be used as output for the stream (default: stdout).
+  -b, --buffer           Buffer all output and write at once instead of streaming.
+  --channel TEXT         Channel(s) to include in output (LLM only, repeatable).
+  --help                 Show this message and exit.
+```
+
+## Predictive model examples
+
+To illustrate the predictive usage, we use the **Scikit-Learn** model introduced in the
+[Serve](/docs/flama-cli/serve/#example-files) section.
 
 ### Model inspection
 
-To start with, let's inspect the model:
-
-```console
-flama model sklearn_model.flm inspect
-
-{"meta": {"id": "43dcc9bb-528f-47e7-b68b-a8b9aa6ffd22", "timestamp": "2025-04-03T19:47:56.590410", "framework": {"lib": "sklearn", "version": "1.8.0"}, "model": {"obj": "MLPClassifier", "info": {"activation": "tanh", "alpha": 0.0001, "batch_size": "auto", "beta_1": 0.9, "beta_2": 0.999, "early_stopping": false, "epsilon": 1e-08, "hidden_layer_sizes": [10], "learning_rate": "constant", "learning_rate_init": 0.001, "max_fun": 15000, "max_iter": 2000, "momentum": 0.9, "n_iter_no_change": 10, "nesterovs_momentum": true, "power_t": 0.5, "random_state": 0, "shuffle": true, "solver": "adam", "tol": 0.0001, "validation_fraction": 0.1, "verbose": false, "warm_start": false}, "params": {"solver": "adam"}, "metrics": {"recall": "0.95"}}, "extra": {"model_version": "1.0.0", "model_description": "This is a test model", "model_author": "John Doe", "model_license": "MIT", "tags": ["test", "example"]}}, "artifacts": {"foo.json": "/var/folders/h4/vc_99fk53b93ttsv18ss8vhw0000gn/T/tmppzdv2rur/artifacts/foo.json"}}
-```
-
-As we can see, the model metadata is returned in JSON format. If we want to get a more
-human-readable output, we can use the **--pretty** option:
+To start with, let us inspect the model:
 
 ```console
 flama model sklearn_model.flm inspect --pretty
 
 {
-    "artifacts": {
-        "foo.json": "/var/folders/h4/vc_99fk53b93ttsv18ss8vhw0000gn/T/tmpcnw6yms0/artifacts/foo.json"
-    },
+    "manifest": [
+        "foo.json"
+    ],
     "meta": {
-        "extra": {
-            "model_author": "John Doe",
-            "model_description": "This is a test model",
-            "model_license": "MIT",
-            "model_version": "1.0.0",
-            "tags": [
-                "test",
-                "example"
-            ]
-        },
+        "id": "43dcc9bb-528f-47e7-b68b-a8b9aa6ffd22",
+        "timestamp": "2025-04-03T19:47:56.590410",
         "framework": {
+            "family": "ml",
             "lib": "sklearn",
             "version": "1.8.0"
         },
-        "id": "43dcc9bb-528f-47e7-b68b-a8b9aa6ffd22",
         "model": {
-            "info": {
-                "activation": "tanh",
-                "alpha": 0.0001,
-                "batch_size": "auto",
-                "beta_1": 0.9,
-                "beta_2": 0.999,
-                "early_stopping": false,
-                "epsilon": 1e-08,
-                "hidden_layer_sizes": [
-                    10
-                ],
-                "learning_rate": "constant",
-                "learning_rate_init": 0.001,
-                "max_fun": 15000,
-                "max_iter": 2000,
-                "momentum": 0.9,
-                "n_iter_no_change": 10,
-                "nesterovs_momentum": true,
-                "power_t": 0.5,
-                "random_state": 0,
-                "shuffle": true,
-                "solver": "adam",
-                "tol": 0.0001,
-                "validation_fraction": 0.1,
-                "verbose": false,
-                "warm_start": false
-            },
-            "metrics": {
-                "recall": "0.95"
-            },
             "obj": "MLPClassifier",
-            "params": {
-                "solver": "adam"
-            }
+            "params": {"solver": "adam"},
+            "metrics": {"recall": "0.95"}
         },
-        "timestamp": "2025-04-03T19:47:56.590410"
+        "extra": {
+            "model_version": "1.0.0",
+            "model_author": "John Doe"
+        }
     }
 }
 ```
 
-The usefulness of the inspect command is that it allows us to visualise
-all the relevant information associated to the model without having to load it,
-and with the ease of a single command. This can be used to verify the model
-integrity and version, amongst other things, within the context of a **continuous
-integration and continuous deployment process**.
+The usefulness of `inspect` is that it lets us see all the relevant information about a model without loading it, which
+is handy for verifying model integrity and version within a continuous integration and continuous deployment (CI/CD)
+process.
 
-### Inline input prediction
+### Inline input inference
 
-Now that we know how to inspect a model, let's make a prediction by using the
-predict command:
+Now let us run an inference by piping input through `run`:
 
 ```console
-echo '[[0, 0], [0, 1], [1, 0], [1, 1]]' | flama model sklearn_model.flm predict
+echo '[[0, 0], [0, 1], [1, 0], [1, 1]]' | flama model sklearn_model.flm run
 
 [0, 1, 1, 0]
 ```
 
-If we want to get a more human-readable output, we can use the **--pretty** option:
+The `--pretty` option formats the output:
 
 ```console
-echo '[[0, 0], [0, 1], [1, 0], [1, 1]]' | flama model sklearn_model.flm predict --pretty
+echo '[[0, 0], [0, 1], [1, 0], [1, 1]]' | flama model sklearn_model.flm run --pretty
 
 [
     0,
@@ -213,44 +180,91 @@ echo '[[0, 0], [0, 1], [1, 0], [1, 1]]' | flama model sklearn_model.flm predict 
 ]
 ```
 
-### File input prediction
+### File input inference
 
-The predict command can also be used to make predictions from a file:
-
-```console
-flama model sklearn_model.flm predict --file input.json --pretty
-
-[
-    0,
-    1,
-    1,
-    0
-]
-```
-
-The output of any prediction can be stored in a file by using the **--output** option:
+The `run` command can also read its input from a file and write its output to another:
 
 ```console
-flama model sklearn_model.flm predict --input input.json --output output.json
+flama model sklearn_model.flm run --input input.json --output output.json
 ```
 
 ### Piping several models together
 
-The default behaviour of the predict command is to receive and return data through
-the standard input and output. This allows us to pipe several models together
-in a single command. For example, let's say we have models **model_a.flm** and **model_b.flm**,
-and we need to make a prediction with **model_a.flm** and then use the output of that
-prediction as input for **model_b.flm**. This can be done by using the following command:
+Because `run` reads from standard input and writes to standard output by default, we can pipe several models together in
+a single command. For example, to feed the output of **model_a.flm** into **model_b.flm**:
 
 ```console
-echo '[0, 1, 2, 3]' | flama model model_a.flm predict | flama model model_b.flm predict
+echo '[0, 1, 2, 3]' | flama model model_a.flm run | flama model model_b.flm run
 
 [1, 0, 1, 0]
 ```
 
-This can be generalised to consider as many models as you need by following the general
-pattern:
+This generalises to as many models as you need:
 
 ```console
-echo 'input' | flama model model_1.flm predict | flama model model_2.flm predict | ... | flama model model_n.flm predict
+echo 'input' | flama model model_1.flm run | flama model model_2.flm run | ... | flama model model_n.flm run
 ```
+
+## Generative model examples
+
+For generative usage, we use the `google_gemma-4-E2B-it.flm` artifact fetched in
+[getting models](/docs/generative-ai/getting-models/).
+
+### One-shot generation
+
+Pipe a prompt to `run` to get the full response once generation completes:
+
+```console
+echo "What is Python?" | flama model google_gemma-4-E2B-it.flm run
+
+Python is a high-level, general-purpose programming language known for its readability.
+```
+
+Add a system instruction (chat transport only) or override generation parameters with repeatable `--param`:
+
+```console
+echo "Explain dependency injection." | flama model google_gemma-4-E2B-it.flm run \
+  --system "Be concise." \
+  --param temperature=0.7 \
+  --param max_tokens=100
+```
+
+### Streaming generation
+
+The `stream` command emits the response as it is produced, which is the natural way to read long generations at the
+terminal:
+
+```console
+echo "Explain dependency injection." | flama model google_gemma-4-E2B-it.flm stream
+
+Dependency injection is a pattern where a component receives its dependencies from the outside...
+```
+
+### Multi-turn conversations
+
+With `--transport conversation`, the input is a JSON list of messages rather than a single prompt:
+
+```console
+flama model google_gemma-4-E2B-it.flm run --transport conversation -i conversation.json
+```
+
+where `conversation.json` is a list of role/content objects, e.g.:
+
+```json
+[
+  {"role": "system", "content": "You are a helpful assistant."},
+  {"role": "user", "content": "What is Flama?"}
+]
+```
+
+### Selecting channels
+
+By default only the user-visible `output` channel is shown. Use `--channel` (repeatable) to include reasoning or other
+channels; pass `all` to include every channel:
+
+```console
+echo "Solve 2 + 2 step by step." | flama model google_gemma-4-E2B-it.flm run --channel all
+```
+
+With a single channel the output is plain text; with several channels (or `all`) the output is a JSON list of
+`{channel, text}` blocks so you can tell each block's origin apart.

--- a/content/docs/4-Flama CLI/5-Get.mdx
+++ b/content/docs/4-Flama CLI/5-Get.mdx
@@ -1,0 +1,95 @@
+---
+title: Get
+wip: true
+---
+
+## Fetching models from a hub
+
+So far we have served models that were already packaged as **.flm** files. But where do those files come from when the
+model lives on a remote hub rather than on your disk? The command **get** downloads a model from a supported source and
+serialises it into the <FlamaName /> `.flm` format in a single step, ready for [serve](/docs/flama-cli/serve/) or
+[model](/docs/flama-cli/model/).
+
+This command works for both traditional predictive models and generative models. The artifact family is
+declared explicitly and recorded in the manifest, so it drives runtime dispatch when the model is later loaded. To
+inspect the command options, run:
+
+```console
+flama get --help
+
+Usage: flama get [OPTIONS] MODEL_NAME
+
+  Download and package a model as .flm.
+
+Options:
+  --source [huggingface]          Model source provider.  [required]
+  --family [ml|llm]               Artifact family recorded in the manifest.
+                                  [required]
+  -o, --output TEXT               Output .flm path (default: <model-name>.flm).
+  --max-concurrent INTEGER RANGE  Maximum number of files to download
+                                  concurrently.  [default: 8; x>=1]
+  --help                          Show this message and exit.
+```
+
+## Parameters
+
+### Selecting the model
+
+The model to fetch is identified by a single positional argument together with two required options that describe where
+it comes from and how it should be treated:
+
+- **MODEL_NAME** (required): the source-specific model identifier, e.g. a [HuggingFace](https://huggingface.co/)
+  repository such as `google/gemma-4-E2B-it`.
+- **source** (required): the provider to download from. Currently `huggingface` is supported.
+- **family** (required): `ml` for traditional predictive models, or `llm` for generative models. This choice is
+  persisted in the `.flm` manifest and drives runtime dispatch, so it cannot be changed without repacking.
+
+### Output options
+
+The remaining options control where the artifact is written and how many files are fetched at once:
+
+- **output** (`-o`): the destination `.flm` path. Defaults to `<model-name>.flm` with slashes replaced by underscores,
+  so `google/gemma-4-E2B-it` becomes `google_gemma-4-E2B-it.flm`.
+- **max-concurrent**: the maximum number of files to download in parallel (default: 8).
+
+## Examples
+
+### Predictive model
+
+To download and package a predictive model from HuggingFace as an `ml` artifact:
+
+```console
+flama get --source huggingface --family ml scikit-learn/Fish-Weight
+
+Downloading ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 4.1 MB 12.0 MB/s 0:00:00
+Packaging...
+Model saved to scikit-learn_Fish-Weight.flm
+```
+
+### Generative model
+
+To download and package a generative model as an `llm` artifact:
+
+```console
+flama get --source huggingface --family llm google/gemma-4-E2B-it
+
+Downloading ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 5.1 GB 24.3 MB/s 0:00:00
+Packaging...
+Model saved to google_gemma-4-E2B-it.flm
+```
+
+### Choosing the output path
+
+By default the artifact is named after the model. Pass `--output` to write it elsewhere:
+
+```console
+flama get --source huggingface --family llm google/gemma-4-E2B-it --output models/assistant.flm
+
+Downloading ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 5.1 GB 31.0 MB/s 0:00:00
+Packaging...
+Model saved to models/assistant.flm
+```
+
+Once a model is packaged, verify it with [model inspect](/docs/flama-cli/model/#inspect) and serve it with
+[serve](/docs/flama-cli/serve/). For more on serving generative models, see the
+[Generative AI](/docs/generative-ai/getting-models/) section.

--- a/content/docs/4-Flama CLI/6-Upgrade.mdx
+++ b/content/docs/4-Flama CLI/6-Upgrade.mdx
@@ -1,0 +1,89 @@
+---
+title: Upgrade
+wip: true
+---
+
+## Upgrading a codebase
+
+Major releases of <FlamaName /> occasionally relocate modules, rename symbols, or change a few call patterns. Rather
+than asking you to track down every affected import by hand, the command **upgrade** rewrites your codebase to match a
+target version, applying a set of codemods (automated source-to-source transformations) across your <PythonName /> files.
+
+Symbols that have no automatic replacement are never silently dropped: they are flagged in place with a `# flama-upgrade`
+marker and reported as manual follow-ups. This page documents the command itself; for the end-to-end migration workflow,
+see the [Upgrading](/docs/getting-started/upgrading/) guide. To inspect the command options, run:
+
+```console
+flama upgrade --help
+
+Usage: flama upgrade [OPTIONS] PATHS...
+
+  Upgrade a Flama codebase to a newer major version.
+
+Options:
+  --to TEXT        Target Flama version (default: latest known migration).
+  --from TEXT      Source Flama version (default: detect installed).
+  --diff / --write Preview a diff (default) or rewrite files in place.
+  --select TEXT    Comma-separated operation ids to run exclusively.
+  --skip TEXT      Comma-separated operation ids to skip.
+  --help           Show this message and exit.
+```
+
+## Parameters
+
+### Paths
+
+- **PATHS** (required): the files and directories to process. Directories are scanned recursively.
+
+### Source and target versions
+
+By default the command detects the version installed in your environment as the source, and uses the latest known
+migration as the target. You can pin either end explicitly:
+
+- **from**: the source version to migrate away from. Defaults to the installed <FlamaName /> version.
+- **to**: the target version to migrate to. Defaults to the latest known migration.
+
+### Preview and apply
+
+- **diff / write**: by default the command previews a unified diff and leaves your files untouched; pass `--write` to
+  apply the changes in place.
+
+### Selecting operations
+
+Every transformation has a stable operation id, so individual codemods can be run or excluded:
+
+- **select**: a comma-separated list of operation ids to run exclusively.
+- **skip**: a comma-separated list of operation ids to skip.
+
+## Examples
+
+### Previewing changes
+
+By default, **upgrade** previews the changes as a unified diff without modifying anything, which makes it the safe first
+step:
+
+```console
+flama upgrade src/
+```
+
+When run in preview mode and changes are found, the command exits with a non-zero status, which makes it convenient to
+use as a check in a continuous integration and continuous deployment (CI/CD) pipeline.
+
+### Applying changes
+
+Once you have reviewed the diff, apply it in place with `--write`:
+
+```console
+flama upgrade --write src/ tests/
+```
+
+### Targeting a version and selecting operations
+
+You can pin the source and target versions, and restrict which codemods run:
+
+```console
+flama upgrade --from 1.0 --to 2.0 --skip move-module:flama.asgi src/
+```
+
+After running the codemods, address any `# flama-upgrade` markers left in your code, then run your test suite to confirm
+the migration is complete. For a step-by-step walkthrough, see the [Upgrading](/docs/getting-started/upgrading/) guide.


### PR DESCRIPTION
## Summary

- Update the Flama CLI documentation for 2.0: rewrite `serve` and `model`, and add the new `get` and `upgrade` commands.
- Pages are flagged `wip: true` for a later manual review pass.

## Test plan

- [x] `npm run build` passes
- [x] CLI pages render with correct command output

Closes #13