### PR TITLE
Upgrading guide for migrating between versions

### DIFF
--- a/content/docs/2-Getting Started/2-Quickstart.mdx
+++ b/content/docs/2-Getting Started/2-Quickstart.mdx
@@ -179,3 +179,6 @@ interested in learning how to serve predictive ML models with <FlamaName />, hea
 [Predictive AI](/docs/predictive-ai/packaging-models/) section. And if you want to serve large language models,
 build a chatbot, or expose tools through the Model Context Protocol, see the
 [Generative AI](/docs/generative-ai/introduction/) section.
+
+If instead you are bringing an existing project to a newer version of <FlamaName />, the
+[Upgrading](/docs/getting-started/upgrading/) guide walks you through migrating your codebase step by step.

--- a/content/docs/2-Getting Started/3-Upgrading.mdx
+++ b/content/docs/2-Getting Started/3-Upgrading.mdx
@@ -31,68 +31,53 @@ target version. Anything that has no automatic replacement is never silently dro
 The workflow that follows is deliberately version agnostic: the same steps apply whichever version you are moving from
 and to.
 
-## Updating the Flama CLI
+## Upgrading your codebase
 
-The first step is to make sure the `flama` command you run is the one that knows about the version you are upgrading to.
-Because the upgrade tool is a standalone command-line application, we recommend installing it with
-[pipx](https://pipx.pypa.io/), which keeps the CLI in its own isolated environment, separate from any project's
-dependencies:
+With the concepts in place, let's walk through a typical upgrade, from previewing the changes to confirming that your
+project still behaves as expected.
+
+### Previewing the changes
+
+The first step is always to see what would change, without altering a single file. The recommended way to run the
+command is with [pipx](https://pipx.pypa.io/), which fetches and runs it in a throwaway environment, leaving your
+project's dependencies untouched:
 
 ```console
-pipx install flama
+pipx run flama upgrade src/ tests/
 ```
 
-If you already manage the CLI with pipx, update it to the latest release before upgrading:
+Point the command at the files and directories you want to process; directories are scanned recursively. Alternatively,
+install <FlamaName /> into your active environment and call the command directly:
 
 ```console
-pipx upgrade flama
-```
-
-You can also run a one-off invocation without a persistent installation, which is handy for pinning an exact version:
-
-```console
-pipx run flama upgrade --help
-```
-
-Alternatively, if you prefer to manage everything with [pip](https://pip.pypa.io/) inside your active environment, install
-or update <FlamaName /> there:
-
-```console
-pip install --upgrade flama
-```
-
-> [!WARNING]
-> The upgrade command rewrites files in place when applied. Commit or stash your work first, so that you always have a
-> clean diff to review and can revert if needed.
-
-## Previewing the changes
-
-By default, **upgrade** previews the changes as a unified diff without modifying anything. This is the safe first step:
-point the command at the files and directories you want to process, where directories are scanned recursively.
-
-```console
+pip install flama
 flama upgrade src/ tests/
 ```
 
-When run in this preview mode and changes are found, the command exits with a non-zero status. This makes it convenient
-to use as a check, as we will see [below](#upgrading-in-continuous-integration).
+By default, **upgrade** previews the changes as a unified diff and modifies nothing, which makes this the safe first
+step. When it finds pending changes in this mode, it exits with a non-zero status — a detail we will
+[put to use](#upgrading-in-continuous-integration) shortly.
 
 Read through the diff carefully. Automatic rewrites generally fall into a few categories: modules that moved to a new
 location, symbols that were renamed or relocated, and call patterns that changed shape. Anything the command cannot
 rewrite on its own is left untouched and tagged with a `# flama-upgrade` marker for you to address by hand.
 
-## Applying the changes
+### Applying the changes
 
-Once you are happy with the proposed diff, apply it in place with `--write`:
+Once you are happy with the proposed diff, apply it in place with the `--write` flag.
+
+> [!WARNING]
+> The upgrade command rewrites files in place when applied. Commit or stash your work first, so that you always have a
+> clean diff to review and can revert if needed.
 
 ```console
 flama upgrade --write src/ tests/
 ```
 
-The command now edits your files directly. Since you reviewed the diff in the previous step and your working tree was
+The command now edits your files directly. Because you reviewed the diff in the previous step and your working tree was
 clean, you can inspect the result with your version control tooling and revert selectively if anything looks off.
 
-## Resolving manual follow-ups
+### Resolving manual follow-ups
 
 Not every change can be made mechanically. When a symbol has been removed without a drop-in replacement, or a pattern
 needs a decision only you can make, the command leaves a `# flama-upgrade` marker at the relevant line and lists it as a
@@ -102,27 +87,22 @@ follow-up. Search your codebase for the markers and resolve each one:
 grep -rn "# flama-upgrade" src/ tests/
 ```
 
-Each marker is accompanied by a short note explaining what changed and what to do instead. Work through them, remove the
-markers as you go, and your migration is complete once none remain.
+Each marker is accompanied by a short note explaining what changed and what to do instead. Work through them, removing
+the markers as you go. Once none remain, pin your project's <FlamaName /> dependency to the new version, reinstall it,
+and run your test suite to confirm the migration is complete.
 
-## Targeting a version and selecting operations
+### Targeting a specific version
 
 By default, the command detects the version installed in the environment as the source, and uses the latest known
-migration as the target. You can make either explicit, which is recommended when running the CLI from an isolated pipx
-environment where the detected version may differ from your project's:
+migration as the target. When you run it from an isolated pipx environment, where the detected version may differ from
+your project's, it is worth being explicit about both ends:
 
 ```console
 flama upgrade --from 1.0 --to 2.0 src/
 ```
 
-When you want fine-grained control over which transformations run, use `--select` to run only specific operations, or
-`--skip` to exclude them. Both accept a comma-separated list of operation ids:
-
-```console
-flama upgrade --skip move-module:flama.asgi src/
-```
-
-For the full list of options, run `flama upgrade --help` or see the [Upgrade](/docs/flama-cli/upgrade/) command reference.
+You can also restrict which transformations run with `--select` and `--skip`. For the full list of options, run
+`flama upgrade --help` or see the [Upgrade](/docs/flama-cli/upgrade/) command reference.
 
 ## Upgrading in continuous integration
 
@@ -134,18 +114,5 @@ codebase has drifted behind the targeted version, reminding you to run the upgra
 flama upgrade src/ tests/
 ```
 
-## Putting it all together
-
-A typical upgrade, from a clean working tree to a passing test suite, looks like this:
-
-```console
-pipx upgrade flama                    # get the CLI for the target version
-flama upgrade src/ tests/             # preview the diff
-flama upgrade --write src/ tests/     # apply it
-grep -rn "# flama-upgrade" src/ tests/  # find manual follow-ups
-pip install --upgrade flama           # update the dependency in your project
-pytest                                # confirm everything works
-```
-
-With that, your project is aligned with the new version of <FlamaName />. To explore the command's options in more
+With that, your project stays aligned with the latest version of <FlamaName />. To explore the command's options in more
 detail, head to the [Upgrade](/docs/flama-cli/upgrade/) reference in the [Flama CLI](/docs/flama-cli/run/) section.

--- a/content/docs/2-Getting Started/3-Upgrading.mdx
+++ b/content/docs/2-Getting Started/3-Upgrading.mdx
@@ -1,0 +1,151 @@
+---
+title: Upgrading
+wip: true
+---
+
+Software evolves, and <FlamaName /> is no exception. As the framework grows, a new major release occasionally relocates
+a module, renames a symbol, or tightens a signature. To spare you from chasing every one of these changes by hand,
+<FlamaName /> ships an **upgrade** command that rewrites your codebase to match a newer version automatically. This page
+walks through the upgrade process end to end, so that moving a project from one major version to the next is a routine,
+low-risk task rather than a tedious migration.
+
+## How upgrades work
+
+In <FlamaName />, an **upgrade** brings two things into line with a newer release: the library installed in your
+environment, and the source code of your project that depends on it. Minor and patch releases are backwards compatible,
+so updating the library is enough. Major releases are where public interfaces may shift, and that is precisely what the
+`flama upgrade` command is built for.
+
+Under the hood, the command applies **codemods** — automated source-to-source transformations — across the <PythonName />
+files you point it at. It rewrites import statements, renamed symbols, and a handful of call patterns so they match the
+target version. Anything that has no automatic replacement is never silently dropped: it is flagged in place with a
+`# flama-upgrade` marker and reported as a manual follow-up.
+
+**Why lean on the command instead of migrating by hand?**
+
+- **Completeness**: every affected import and reference under the given paths is rewritten, so nothing is missed.
+- **Safety**: by default the command only previews a diff, leaving your files untouched until you choose to apply it.
+- **Transparency**: changes that require human judgement are surfaced explicitly, rather than guessed at.
+- **Repeatability**: the same command can run locally and in continuous integration, so upgrades stay verifiable.
+
+The workflow that follows is deliberately version agnostic: the same steps apply whichever version you are moving from
+and to.
+
+## Updating the Flama CLI
+
+The first step is to make sure the `flama` command you run is the one that knows about the version you are upgrading to.
+Because the upgrade tool is a standalone command-line application, we recommend installing it with
+[pipx](https://pipx.pypa.io/), which keeps the CLI in its own isolated environment, separate from any project's
+dependencies:
+
+```console
+pipx install flama
+```
+
+If you already manage the CLI with pipx, update it to the latest release before upgrading:
+
+```console
+pipx upgrade flama
+```
+
+You can also run a one-off invocation without a persistent installation, which is handy for pinning an exact version:
+
+```console
+pipx run flama upgrade --help
+```
+
+Alternatively, if you prefer to manage everything with [pip](https://pip.pypa.io/) inside your active environment, install
+or update <FlamaName /> there:
+
+```console
+pip install --upgrade flama
+```
+
+> [!WARNING]
+> The upgrade command rewrites files in place when applied. Commit or stash your work first, so that you always have a
+> clean diff to review and can revert if needed.
+
+## Previewing the changes
+
+By default, **upgrade** previews the changes as a unified diff without modifying anything. This is the safe first step:
+point the command at the files and directories you want to process, where directories are scanned recursively.
+
+```console
+flama upgrade src/ tests/
+```
+
+When run in this preview mode and changes are found, the command exits with a non-zero status. This makes it convenient
+to use as a check, as we will see [below](#upgrading-in-continuous-integration).
+
+Read through the diff carefully. Automatic rewrites generally fall into a few categories: modules that moved to a new
+location, symbols that were renamed or relocated, and call patterns that changed shape. Anything the command cannot
+rewrite on its own is left untouched and tagged with a `# flama-upgrade` marker for you to address by hand.
+
+## Applying the changes
+
+Once you are happy with the proposed diff, apply it in place with `--write`:
+
+```console
+flama upgrade --write src/ tests/
+```
+
+The command now edits your files directly. Since you reviewed the diff in the previous step and your working tree was
+clean, you can inspect the result with your version control tooling and revert selectively if anything looks off.
+
+## Resolving manual follow-ups
+
+Not every change can be made mechanically. When a symbol has been removed without a drop-in replacement, or a pattern
+needs a decision only you can make, the command leaves a `# flama-upgrade` marker at the relevant line and lists it as a
+follow-up. Search your codebase for the markers and resolve each one:
+
+```console
+grep -rn "# flama-upgrade" src/ tests/
+```
+
+Each marker is accompanied by a short note explaining what changed and what to do instead. Work through them, remove the
+markers as you go, and your migration is complete once none remain.
+
+## Targeting a version and selecting operations
+
+By default, the command detects the version installed in the environment as the source, and uses the latest known
+migration as the target. You can make either explicit, which is recommended when running the CLI from an isolated pipx
+environment where the detected version may differ from your project's:
+
+```console
+flama upgrade --from 1.0 --to 2.0 src/
+```
+
+When you want fine-grained control over which transformations run, use `--select` to run only specific operations, or
+`--skip` to exclude them. Both accept a comma-separated list of operation ids:
+
+```console
+flama upgrade --skip move-module:flama.asgi src/
+```
+
+For the full list of options, run `flama upgrade --help` or see the [Upgrade](/docs/flama-cli/upgrade/) command reference.
+
+## Upgrading in continuous integration
+
+Because preview mode exits with a non-zero status whenever it finds pending changes, the command doubles as a guard in a
+continuous integration and continuous deployment (CI/CD) pipeline. Adding the following step fails the build whenever a
+codebase has drifted behind the targeted version, reminding you to run the upgrade before merging:
+
+```console
+flama upgrade src/ tests/
+```
+
+## Putting it all together
+
+A typical upgrade, from a clean working tree to a passing test suite, looks like this:
+
+```console
+pipx upgrade flama                    # get the CLI for the target version
+flama upgrade src/ tests/             # preview the diff
+flama upgrade --write src/ tests/     # apply it
+grep -rn "# flama-upgrade" src/ tests/  # find manual follow-ups
+pip install --upgrade flama           # update the dependency in your project
+pytest                                # confirm everything works
+```
+
+With that, your project is aligned with the new version of <FlamaName />. To explore the command's options in more
+detail, head to the [Upgrade](/docs/flama-cli/upgrade/) reference in the [Flama CLI](/docs/flama-cli/run/) section.


### PR DESCRIPTION
## Summary

- Add a dedicated, version-agnostic **Upgrading** guide to the Getting Started section (`content/docs/2-Getting Started/3-Upgrading.mdx`) that walks through migrating a codebase to a newer major version with `flama upgrade`.
- Cover how upgrades work, updating the CLI (`pipx` as the default, `pip` as the alternative), previewing and applying changes, resolving `# flama-upgrade` follow-ups, targeting versions with `--from`/`--to`/`--select`/`--skip`, CI usage, and an end-to-end recap.
- Add a closing cross-link from the Quickstart page pointing existing projects to the new guide.

The guide is written to apply to any version transition rather than a single release; the `flama upgrade` command reference stays in the CLI section (#13) and is linked from here for the full option list.

## Test plan

- [x] `npm run build` succeeds and prerenders `/docs/getting-started/upgrading/`.
- [x] Page renders correctly in the docs sidebar under Getting Started.
- [x] Cross-link from Quickstart resolves to the new guide.

Closes #20.
